### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Parameter | Range | Description | Default
 -c | file name | Use commanding file |
 -na |  | Disable AMD support |
 
+Beware - with this miner almost all configuration is done via either the API or the JSON file. Setting the pool address, port, wallet address, worker name, etc - all these need to go in the JSON file, or need to be sent to the miner as commands via the API. This is different from most other miners out there, where you configure the pool, the wallet, etc via the command line - *that won't work with excavator*! Read the JSON documentation and see the JSON examples in the repo.
+
 
 # Additional Notices
 


### PR DESCRIPTION
As a total newbie to excavator, I was stumped for a long time and could not make it work. What made it more confusing was the fact that there are various old excavator forks floating around which are configured the traditional way, via command line parameters. But this excavator version is different - it requires that all configuration is passed to it via JSON or API.

See this related issue: https://github.com/nicehash/excavator/issues/96

Eventually I ran excavator under `strace` and that's when I saw it was doing nothing after initialization. It finally dawned on me that this is really different, and the configuration must be somewhere else.

So I made this comment on README.md for folks like me who are confused by the unusual way that excavator is configured.